### PR TITLE
Use Berthold City Light font

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,12 +1,19 @@
 @font-face {
-  font-family: 'CityAlien';
+  font-family: 'Berthold City Light';
+  src: url('fonts/CityLightExtended-Regular.woff2') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}
+
+@font-face {
+  font-family: 'City Mono Extended';
   src: url('fonts/CityLightExtended-Regular.woff2') format('woff2');
   font-weight: normal;
   font-style: normal;
 }
 
 body {
-  font-family: 'CityAlien', monospace;
+  font-family: 'Berthold City Light', 'City Mono Extended', monospace;
   color: #00FF7F;
   background: black;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- use custom Berthold City Light and City Mono Extended fonts for app

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68938c03b78c832cbf4e9c9a5ce9ff64