### PR TITLE
style: enlarge and center start button

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -17,14 +17,19 @@ body {
   color: #00FF7F;
   background: black;
   text-transform: uppercase;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
 }
 
 button {
   background: transparent;
-  border: 2px solid #00FF7F;
+  border: none;
+  outline: none;
   color: #00FF7F;
-  padding: 10px 20px;
-  font-size: 1.5em;
+  padding: 40px 80px;
+  font-size: 6em;
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- center start button with flexbox
- enlarge and remove green outline from start button

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68938dff6e3c832cabb5c38db1b30fb1