### PR TITLE
Remove auto highlighting of input on home page

### DIFF
--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -40,8 +40,6 @@ function showCodeScreen(container) {
       if (!isKnownCode(val)) {
         labelEl.textContent = 'ACCESS DENIED';
         labelEl.classList.add('denied');
-        // очистим/выделим ввод для повторного ввода
-        inputEl.select?.();
         return;
       }
 
@@ -53,12 +51,9 @@ function showCodeScreen(container) {
   });
   mount.appendChild(form);
 
-  // автофокус в поле ввода
   const inputEl = form.querySelector('input');
   const labelEl = form.querySelector('label');
   const defaultLabel = 'Введите код';
-
-  inputEl?.focus({ preventScroll: true });
 
   // при любом вводе — снимаем статус ошибки и возвращаем исходный текст
   inputEl?.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- avoid automatically focusing or selecting the code input on the home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build`


------
https://chatgpt.com/codex/tasks/task_e_68a0d8bcf908832c81e0221f207caebe